### PR TITLE
Update to new template from g8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,7 @@
+name := "libgdx-sbt"
+
+version := "0.1.0"
+
+organization := "com.hagerbot"
+
+seq(giter8Settings :_*)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,6 +1,1 @@
-project.organization=com.hagerbot
-project.name=libgdx-sbt
-sbt.version=0.7.5
-project.version=0.1.0
-build.scala.versions=2.7.7
-project.initialize=false
+sbt.version=0.11.3

--- a/project/build/project.scala
+++ b/project/build/project.scala
@@ -1,5 +1,0 @@
-import sbt._
-
-class TemplateProject(info: ProjectInfo) extends DefaultProject(info) with giter8.Template
-
-

--- a/project/plugins/plugins.scala
+++ b/project/plugins/plugins.scala
@@ -1,5 +1,0 @@
-import sbt._
-
-class Plugins(info: ProjectInfo) extends PluginDefinition(info) {
-  val giter8 = "net.databinder" % "giter8-plugin" % "0.2.0"
-}

--- a/project/project/plugins.scala
+++ b/project/project/plugins.scala
@@ -1,0 +1,6 @@
+import sbt._
+object PluginDef extends Build {
+  lazy val root = Project("plugins", file(".")) dependsOn( g8plugin )
+  lazy val g8plugin =
+    ProjectRef(uri("git://github.com/n8han/giter8#0.4.5.1"), "giter8-plugin")
+}


### PR DESCRIPTION
Seems that support for project/plugins/\* plugin configuration will be removed in next sbt release. Default g8 template created by using

```
g8 n8han/giter8
```

does not have this issue, so I updated it to reflect upstream change.

For reference of why such changes, see:
- http://www.scala-sbt.org/snapshot/docs/Community/ChangeSummary_0.13.0.html
- http://www.scala-sbt.org/0.12.1/docs/Detailed-Topics/Migrating-from-sbt-0.7.x-to-0.10.x.html#create-build-sbt-for-version
- https://github.com/n8han/giter8#using-the-giter8-plugin
