### PR TITLE
Set of small features to make starting new development easier

### DIFF
--- a/src/main/g8/android/src/main/AndroidManifest.xml
+++ b/src/main/g8/android/src/main/AndroidManifest.xml
@@ -3,17 +3,20 @@
       package="$package$"
       android:versionCode="1"
       android:versionName="1.0">
-    <uses-sdk android:targetSdkVersion="$api_level$"
-              android:minSdkVersion="$api_level$"/>
-    <uses-permission android:name="android.permission.WAKE_LOCK" />
+
+    <uses-sdk android:minSdkVersion="$api_level$"
+              android:targetSdkVersion="$api_level$" />
+
     <application android:icon="@drawable/android:star_big_on"
                  android:label="@string/app_name">
-        <activity android:name=".Main"
-                  android:label="@string/app_name">
+        <activity android:name=".Main" android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
     </application>
+
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+
 </manifest>

--- a/src/main/g8/android/src/main/AndroidManifest.xml
+++ b/src/main/g8/android/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
       android:versionCode="1"
       android:versionName="1.0">
 
-    <uses-sdk android:minSdkVersion="$api_level$"
+    <uses-sdk android:minSdkVersion="$min_api_level$"
               android:targetSdkVersion="$api_level$" />
 
     <application android:icon="@drawable/android:star_big_on"

--- a/src/main/g8/android/src/main/AndroidManifest.xml
+++ b/src/main/g8/android/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
       package="$package$"
       android:versionCode="1"
-      android:versionName="1.0">
+      android:versionName="0.1">
 
     <uses-sdk android:minSdkVersion="$min_api_level$"
               android:targetSdkVersion="$api_level$" />

--- a/src/main/g8/android/src/main/AndroidManifest.xml
+++ b/src/main/g8/android/src/main/AndroidManifest.xml
@@ -8,7 +8,8 @@
               android:targetSdkVersion="$api_level$" />
 
     <application android:icon="@drawable/android:star_big_on"
-                 android:label="@string/app_name">
+                 android:label="@string/app_name"
+                 android:debuggable="true">
         <activity android:name=".Main" android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/src/main/g8/android/src/main/proguard.cfg
+++ b/src/main/g8/android/src/main/proguard.cfg
@@ -1,0 +1,1 @@
+-keep class com.badlogic.gdx.backends.android.** { *; }

--- a/src/main/g8/android/src/main/proguard.cfg
+++ b/src/main/g8/android/src/main/proguard.cfg
@@ -1,1 +1,2 @@
 -keep class com.badlogic.gdx.backends.android.** { *; }
+-keep class $package$.** { *; }

--- a/src/main/g8/android/src/main/scala/Main.scala
+++ b/src/main/g8/android/src/main/scala/Main.scala
@@ -11,6 +11,6 @@ class Main extends AndroidApplication {
     config.useCompass = false
     config.useWakelock = true
     config.useGL20 = true
-    initialize(new MyGame(), config)
+    initialize(new $main_class$(), config)
   }
 }

--- a/src/main/g8/common/src/main/scala/$main_class$.scala
+++ b/src/main/g8/common/src/main/scala/$main_class$.scala
@@ -2,6 +2,6 @@ package $package$
 
 import com.badlogic.gdx.Game
 
-class MyGame extends Game {
+class $main_class$ extends Game {
     override def create() {}
 }

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -1,4 +1,5 @@
-name=Game
-package=my.game.pkg
+name=My Game
 api_level=17
 scala_version=2.10.1
+main_class=MyGame
+package=my.game.pkg

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -1,4 +1,5 @@
 name=My Game
+min_api_level=9
 api_level=17
 scala_version=2.10.1
 main_class=MyGame

--- a/src/main/g8/desktop/src/main/scala/Main.scala
+++ b/src/main/g8/desktop/src/main/scala/Main.scala
@@ -8,5 +8,5 @@ object Main extends App {
     cfg.height = 480
     cfg.width = 320
     cfg.useGL20 = true
-    new LwjglApplication(new MyGame(), cfg)
+    new LwjglApplication(new $main_class$(), cfg)
 }

--- a/src/main/g8/ios/Main.cs
+++ b/src/main/g8/ios/Main.cs
@@ -13,7 +13,7 @@ namespace $package$
 	{
 		[Register ("AppDelegate")]
 		public partial class AppDelegate : IOSApplication {
-			public AppDelegate(): base(new MyGame(), getConfig()) {
+			public AppDelegate(): base(new $main_class$(), getConfig()) {
 
 			}
 

--- a/src/main/g8/project/build.scala
+++ b/src/main/g8/project/build.scala
@@ -22,7 +22,7 @@ object Settings {
       keyalias in Android := "change-me",
       mainAssetsPath in Android := file("common/src/main/resources"),
       unmanagedBase <<= baseDirectory( _ /"src/main/libs" ),
-      proguardOption in Android := "-keep class com.badlogic.gdx.backends.android.** { *; }"
+      proguardOption in Android <<= (baseDirectory) { (b) => scala.io.Source.fromFile(b / "src/main/proguard.cfg").mkString }
     )
 
   val updateLibgdx = TaskKey[Unit]("update-gdx", "Updates libgdx")


### PR DESCRIPTION
I've made a small set of changes to manifest and customization to make starting new development easier. There is short list of changes:
- added ability to set minSdkVersion (defaults to 9, because from games/most multimedia apps point of view nothing important changed from that API level, some even say it's API 8, but 9 is safer assumption due to some bugs in 8 that needs special workarounds)
- added ability to set main game class name (I found out that I always change that, so why not allow to customize it during project creation?... default still is MyGame)
- moved proguard configuration to file so people does not have to hack build.scala, and added $package$.*\* to it
- made application debuggable by default
- fixed version difference between manifest and build.scala (0.1 vs 1.0)
- changed default name from "Game" to "My Game" to highlight possibility of spaces in name. It isn't obvious at first where they are possible and where not, so subtle hint like that is good solution I think.

I believe those make starting new project even easier, especially for new users (and we must agree, that Scala for Android unfortunately still isn't established solution).

And of course, thanks for great work on this project, it really was best starting point for my developments after looking at multiple solutions!
