### PR TITLE
Support for Unit and Performance Testing (Desktop and Android) and Instrumentation Testing (Android)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,25 @@ Run the android project on a device:
 
 Visit [android-plugin](https://github.com/jberkel/android-plugin) for a more in-depth guide to android configuration and usage.
 
+## Using unit and instrumentation tests
+
+Run all unit tests from desktop, android and common (subdirectories src/test/scala):
+
+    $ sbt test
+
+Run specific set of unit tests:
+
+    $ sbt "project desktop" test
+
+Use instrumentation tests (directory android-tests):
+
+    $ sbt
+    > android:emulator-start <tab>
+    > android:install-emulator
+    > project android-tests
+    > android:install-emulator
+    > android:test-emulator
+
 ## iOS Support (not currently working)
 
 Open the ios solution in Xamarin Studio and build.

--- a/src/main/g8/android-tests/src/main/AndroidManifest.xml
+++ b/src/main/g8/android-tests/src/main/AndroidManifest.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+      package="$package$.tests"
+      android:versionCode="1"
+      android:versionName="0.1">
+
+    <uses-sdk android:minSdkVersion="$min_api_level$"
+              android:targetSdkVersion="$api_level$" />
+
+    <application android:icon="@drawable/android:star_big_on"
+                 android:label="@string/app_name"
+                 android:debuggable="true">
+        <activity android:name=".Main" android:label="@string/app_name">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+        <uses-library android:name="android.test.runner" />
+    </application>
+
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+
+    <instrumentation android:label="Tests"
+                     android:targetPackage="$package$"
+                     android:name="android.test.InstrumentationTestRunner" />
+</manifest>

--- a/src/main/g8/android-tests/src/main/res/values/strings.xml
+++ b/src/main/g8/android-tests/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">$name$</string>
+</resources>

--- a/src/main/g8/android-tests/src/main/scala/Tests.scala
+++ b/src/main/g8/android-tests/src/main/scala/Tests.scala
@@ -1,0 +1,11 @@
+package $package$.tests
+
+import $package$._
+import junit.framework.Assert._
+import _root_.android.test.AndroidTestCase
+
+class AndroidTests extends AndroidTestCase {
+  def testPackageIsCorrect() {
+    assertEquals("$package$", getContext.getPackageName)
+  }
+}

--- a/src/main/g8/common/src/test/scala/Specs.scala
+++ b/src/main/g8/common/src/test/scala/Specs.scala
@@ -1,0 +1,13 @@
+import $package$
+import org.scalatest.FunSpec
+
+
+class Specs extends FunSpec {
+
+    describe("A game world") {
+
+        it("should have player instance") (pending)
+
+    }
+
+}

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -1,7 +1,8 @@
 name=My Game
+main_class=MyGame
+package=my.game.pkg
 min_api_level=9
 api_level=17
 scala_version=2.10.1
-main_class=MyGame
-package=my.game.pkg
 scalatest_version=1.9.1
+scalameter_version=0.3

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -4,3 +4,4 @@ api_level=17
 scala_version=2.10.1
 main_class=MyGame
 package=my.game.pkg
+scalatest_version=1.9.1

--- a/src/main/g8/project/build.scala
+++ b/src/main/g8/project/build.scala
@@ -8,8 +8,7 @@ object Settings {
   lazy val common = Defaults.defaultSettings ++ Seq (
     version := "0.1",
     scalaVersion := "$scala_version$",
-    libraryDependencies += "org.scalatest" %% "scalatest" % "$scalatest_version$" % "test",
-    updateLibgdxTask
+    libraryDependencies += "org.scalatest" %% "scalatest" % "$scalatest_version$" % "test"
    )
 
   lazy val desktop = Settings.common ++ Seq (
@@ -92,11 +91,17 @@ object LibgdxBuild extends Build {
     "desktop",
     file("desktop"),
     settings = Settings.desktop
-  ) dependsOn common
+  ) dependsOn(common % "compile->compile;test->test")
 
   lazy val android = Project (
     "android",
     file("android"),
     settings = Settings.android
-  ) dependsOn common
+  ) dependsOn(common % "compile->compile;test->test")
+
+  lazy val all = Project (
+    "all-platforms",
+    file("."),
+    settings = Settings.common :+ Settings.updateLibgdxTask
+  ) aggregate(common, desktop, android)
 }

--- a/src/main/g8/project/build.scala
+++ b/src/main/g8/project/build.scala
@@ -8,6 +8,7 @@ object Settings {
   lazy val common = Defaults.defaultSettings ++ Seq (
     version := "0.1",
     scalaVersion := "$scala_version$",
+    libraryDependencies += "org.scalatest" %% "scalatest" % "$scalatest_version$" % "test",
     updateLibgdxTask
    )
 

--- a/src/main/g8/project/build.scala
+++ b/src/main/g8/project/build.scala
@@ -5,13 +5,16 @@ import org.scalasbt.androidplugin._
 import org.scalasbt.androidplugin.AndroidKeys._
 
 object Settings {
+  lazy val scalameter = new TestFramework("org.scalameter.ScalaMeterFramework")
+
   lazy val common = Defaults.defaultSettings ++ Seq (
     version := "0.1",
     scalaVersion := "$scala_version$",
     resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
     libraryDependencies += "org.scalatest" %% "scalatest" % "$scalatest_version$" % "test",
     libraryDependencies += "com.github.axel22" %% "scalameter" % "$scalameter_version$" % "test",
-    testFrameworks += new TestFramework("org.scalameter.ScalaMeterFramework")
+    testFrameworks += scalameter,
+    testOptions += Tests.Argument(scalameter, "-preJDK7")
    )
 
   lazy val desktop = Settings.common ++ Seq (

--- a/src/main/g8/project/build.scala
+++ b/src/main/g8/project/build.scala
@@ -8,7 +8,10 @@ object Settings {
   lazy val common = Defaults.defaultSettings ++ Seq (
     version := "0.1",
     scalaVersion := "$scala_version$",
-    libraryDependencies += "org.scalatest" %% "scalatest" % "$scalatest_version$" % "test"
+    resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
+    libraryDependencies += "org.scalatest" %% "scalatest" % "$scalatest_version$" % "test",
+    libraryDependencies += "com.github.axel22" %% "scalameter" % "$scalameter_version$" % "test",
+    testFrameworks += new TestFramework("org.scalameter.ScalaMeterFramework")
    )
 
   lazy val desktop = Settings.common ++ Seq (

--- a/src/main/g8/project/build.scala
+++ b/src/main/g8/project/build.scala
@@ -104,4 +104,12 @@ object LibgdxBuild extends Build {
     file("."),
     settings = Settings.common :+ Settings.updateLibgdxTask
   ) aggregate(common, desktop, android)
+
+  lazy val tests = Project (
+    "android-tests",
+    file("android-tests"),
+    settings = Settings.android ++
+               AndroidTest.androidSettings ++
+               Seq ( name := "$name$Tests" )
+  ) dependsOn android
 }


### PR DESCRIPTION
Testing frameworks are very important for my style of working, and I believe everyone can benefit from some unit or instrumentation tests. I've used those features in jberkel/android-app.g8 and missed it from this template. Those 4 commits are a try to bring in slightly simplified version of those in.

The biggest change is probably adding "all-platforms" aggregated target. That way, we can compile or test all platforms at once by issuing single "test" sbt command. Instrumentation testing is little harder, but it uses commands from android-plugin so is quite standard. Used android-tests for it to underline, that it is android based.

If someone does not need tests, this does not change much - one can just ignore those then and use everything like it was. Library dependencies are added only when test is used (it has % test as qualifier).

I also provided one (pending) unit test in common, and one actual test in Instrumentation test as examples.

Since last edit, this also includes ScalaMeter (which is very useful, but hard to get right on JDK6).
