### PR TITLE
Improve default proguard setup

### DIFF
--- a/src/main/g8/android/src/main/proguard.cfg
+++ b/src/main/g8/android/src/main/proguard.cfg
@@ -1,1 +1,5 @@
 -keep class com.badlogic.gdx.backends.android.** { *; }
+
+# See bug https://issues.scala-lang.org/browse/SI-5397
+-keep class scala.collection.SeqLike { public protected *; }
+

--- a/src/main/g8/android/src/main/proguard.cfg
+++ b/src/main/g8/android/src/main/proguard.cfg
@@ -1,8 +1,5 @@
 -keep class com.badlogic.gdx.backends.android.** { *; }
 
-# See bug https://issues.scala-lang.org/browse/SI-5397
--keep class scala.collection.SeqLike { public protected *; }
-
 # Fix accesses to class members by means of introspection
 # (for empty projects)
 -keepclassmembernames class scala.concurrent.forkjoin.ForkJoinPool {
@@ -22,3 +19,12 @@
     scala.concurrent.forkjoin.LinkedTransferQueue$Node next;
     java.lang.Thread waiter;
 }
+
+# See bug https://issues.scala-lang.org/browse/SI-5397
+-keep class scala.collection.SeqLike { public protected *; }
+# This needs also descriptor classes
+-keep public class scala.Function1
+-keep public class scala.Function2
+-keep public class scala.collection.GenSeq
+-keep public class scala.collection.generic.CanBuildFrom
+-keep public class scala.math.Ordering

--- a/src/main/g8/android/src/main/proguard.cfg
+++ b/src/main/g8/android/src/main/proguard.cfg
@@ -3,3 +3,22 @@
 # See bug https://issues.scala-lang.org/browse/SI-5397
 -keep class scala.collection.SeqLike { public protected *; }
 
+# Fix accesses to class members by means of introspection
+# (for empty projects)
+-keepclassmembernames class scala.concurrent.forkjoin.ForkJoinPool {
+    long ctl;
+    long parkBlocker;
+}
+-keepclassmembernames class scala.concurrent.forkjoin.ForkJoinPool$WorkQueue {
+    int runState;
+}
+-keepclassmembernames class scala.concurrent.forkjoin.LinkedTransferQueue {
+    scala.concurrent.forkjoin.LinkedTransferQueue$Node head;
+    scala.concurrent.forkjoin.LinkedTransferQueue$Node tail;
+    int sweepVotes;
+}
+-keepclassmembernames class scala.concurrent.forkjoin.LinkedTransferQueue$Node {
+    java.lang.Object item;
+    scala.concurrent.forkjoin.LinkedTransferQueue$Node next;
+    java.lang.Thread waiter;
+}

--- a/src/main/g8/android/src/main/proguard.cfg
+++ b/src/main/g8/android/src/main/proguard.cfg
@@ -1,4 +1,27 @@
+## LibGDX
+
+# Keep Android backend
 -keep class com.badlogic.gdx.backends.android.** { *; }
+# This needs also descriptor classes
+-keep public class com.badlogic.gdx.Screen
+-keep public class com.badlogic.gdx.Application
+-keep public class com.badlogic.gdx.ApplicationListener
+-keep public class com.badlogic.gdx.LifecycleListener
+-keep public class com.badlogic.gdx.InputProcessor
+-keep public class com.badlogic.gdx.files.FileHandle
+-keep public class com.badlogic.gdx.Files$FileType
+-keep public class com.badlogic.gdx.Graphics$DisplayMode
+-keep public class com.badlogic.gdx.Input$TextInputListener
+-keep public class com.badlogic.gdx.Input$Peripheral
+-keep public class com.badlogic.gdx.Input$Orientation
+-keep public class com.badlogic.gdx.Net$HttpRequest
+-keep public class com.badlogic.gdx.Net$HttpResponseListener
+-keep public class com.badlogic.gdx.Net$Protocol
+-keep public class com.badlogic.gdx.net.SocketHints
+-keep public class com.badlogic.gdx.net.ServerSocketHints
+-keep public class com.badlogic.gdx.utils.Array
+
+## Scala
 
 # Fix accesses to class members by means of introspection
 # (for empty projects)
@@ -28,3 +51,4 @@
 -keep public class scala.collection.GenSeq
 -keep public class scala.collection.generic.CanBuildFrom
 -keep public class scala.math.Ordering
+

--- a/src/main/g8/android/src/main/proguard.cfg
+++ b/src/main/g8/android/src/main/proguard.cfg
@@ -1,2 +1,1 @@
 -keep class com.badlogic.gdx.backends.android.** { *; }
--keep class $package$.** { *; }

--- a/src/main/g8/project/build.scala
+++ b/src/main/g8/project/build.scala
@@ -22,7 +22,9 @@ object Settings {
       keyalias in Android := "change-me",
       mainAssetsPath in Android := file("common/src/main/resources"),
       unmanagedBase <<= baseDirectory( _ /"src/main/libs" ),
-      proguardOption in Android <<= (baseDirectory) { (b) => scala.io.Source.fromFile(b / "src/main/proguard.cfg").mkString }
+      proguardOption in Android <<= (baseDirectory) {
+        (b) => scala.io.Source.fromFile(b / "src/main/proguard.cfg").getLines.map(_.takeWhile(_!='#')).filter(_!="").mkString("\n")
+      }
     )
 
   val updateLibgdx = TaskKey[Unit]("update-gdx", "Updates libgdx")


### PR DESCRIPTION
This set of commits improves default proguard setup. There is summary of changes:
- allow comments in proguard file
- eliminate all warnings for empty project, i.e.
  - add descriptor classes needed for LibGDX
  - add field kept by means of introspection
- add workaround for hard to find but easy to trigger bug https://issues.scala-lang.org/browse/SI-5397 (I was hitting it with every non trivial code, like using Future[...] to load text file).
