### PR TITLE
Disable forced quit

### DIFF
--- a/src/main/g8/desktop/src/main/scala/Main.scala
+++ b/src/main/g8/desktop/src/main/scala/Main.scala
@@ -8,5 +8,6 @@ object Main extends App {
     cfg.height = 480
     cfg.width = 320
     cfg.useGL20 = true
+    cfg.forceExit = false
     new LwjglApplication(new $main_class$(), cfg)
 }


### PR DESCRIPTION
Forced quit is workaround for apps running on old versions of MacOS X inside
Java Webstart. It quits the application by harsh System.exit(-1), that is
caught by SBT as exception.

I believe it is better to disable it during development (development even if
done on Mac, isn't done inside Webstart), making the application close nicely.
It means, that if you see exception on console, something is really wrong
with your code, not with Webstart on MacOS X.
