### PR TITLE
Fix proguard.cfg template generation

### DIFF
--- a/src/main/g8/android/src/main/proguard.cfg
+++ b/src/main/g8/android/src/main/proguard.cfg
@@ -9,14 +9,14 @@
 -keep public class com.badlogic.gdx.LifecycleListener
 -keep public class com.badlogic.gdx.InputProcessor
 -keep public class com.badlogic.gdx.files.FileHandle
--keep public class com.badlogic.gdx.Files$FileType
--keep public class com.badlogic.gdx.Graphics$DisplayMode
--keep public class com.badlogic.gdx.Input$TextInputListener
--keep public class com.badlogic.gdx.Input$Peripheral
--keep public class com.badlogic.gdx.Input$Orientation
--keep public class com.badlogic.gdx.Net$HttpRequest
--keep public class com.badlogic.gdx.Net$HttpResponseListener
--keep public class com.badlogic.gdx.Net$Protocol
+-keep public class com.badlogic.gdx.Files\$FileType
+-keep public class com.badlogic.gdx.Graphics\$DisplayMode
+-keep public class com.badlogic.gdx.Input\$TextInputListener
+-keep public class com.badlogic.gdx.Input\$Peripheral
+-keep public class com.badlogic.gdx.Input\$Orientation
+-keep public class com.badlogic.gdx.Net\$HttpRequest
+-keep public class com.badlogic.gdx.Net\$HttpResponseListener
+-keep public class com.badlogic.gdx.Net\$Protocol
 -keep public class com.badlogic.gdx.net.SocketHints
 -keep public class com.badlogic.gdx.net.ServerSocketHints
 -keep public class com.badlogic.gdx.utils.Array
@@ -29,17 +29,17 @@
     long ctl;
     long parkBlocker;
 }
--keepclassmembernames class scala.concurrent.forkjoin.ForkJoinPool$WorkQueue {
+-keepclassmembernames class scala.concurrent.forkjoin.ForkJoinPool\$WorkQueue {
     int runState;
 }
 -keepclassmembernames class scala.concurrent.forkjoin.LinkedTransferQueue {
-    scala.concurrent.forkjoin.LinkedTransferQueue$Node head;
-    scala.concurrent.forkjoin.LinkedTransferQueue$Node tail;
+    scala.concurrent.forkjoin.LinkedTransferQueue\$Node head;
+    scala.concurrent.forkjoin.LinkedTransferQueue\$Node tail;
     int sweepVotes;
 }
--keepclassmembernames class scala.concurrent.forkjoin.LinkedTransferQueue$Node {
+-keepclassmembernames class scala.concurrent.forkjoin.LinkedTransferQueue\$Node {
     java.lang.Object item;
-    scala.concurrent.forkjoin.LinkedTransferQueue$Node next;
+    scala.concurrent.forkjoin.LinkedTransferQueue\$Node next;
     java.lang.Thread waiter;
 }
 


### PR DESCRIPTION
I've skipped obvious issue... template for proguard.cfg wasn't generating
correctly because I forgot to escape dollar signs. Sorry about that. Anyway,
this commit fixes it.

I don't know how it happened, probably copied over wrong file during tests, because I am sure I tested generation before :-(
