### PR TITLE
proguard.cfg update for Scala 2.10.2

### DIFF
--- a/src/main/g8/android/src/main/proguard.cfg
+++ b/src/main/g8/android/src/main/proguard.cfg
@@ -24,13 +24,19 @@
 ## Scala
 
 # Fix accesses to class members by means of introspection
-# (for empty projects)
 -keepclassmembernames class scala.concurrent.forkjoin.ForkJoinPool {
     long ctl;
-    long parkBlocker;
+    long stealCount;
+    int plock;
+    int qlock;
+    int indexSeed;
+    ** parkBlocker; # I can't find what type it should be, so keep all
 }
 -keepclassmembernames class scala.concurrent.forkjoin.ForkJoinPool\$WorkQueue {
-    int runState;
+    int qlock;
+}
+-keepclassmembernames class scala.concurrent.forkjoin.ForkJoinTask {
+    int status;
 }
 -keepclassmembernames class scala.concurrent.forkjoin.LinkedTransferQueue {
     scala.concurrent.forkjoin.LinkedTransferQueue\$Node head;


### PR DESCRIPTION
In Scala 2.10.2 Fork/Join pool changed, new proguard.cfg mirrors
those changes for members accessed trough introspection.

See https://issues.scala-lang.org/browse/SI-7442 for details.
