### PR TITLE
Increase default minimum API level to 10

### DIFF
--- a/src/main/g8/android-tests/src/main/AndroidManifest.xml
+++ b/src/main/g8/android-tests/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
       android:versionCode="1"
       android:versionName="0.1">
 
-    <uses-sdk android:minSdkVersion="9"
+    <uses-sdk android:minSdkVersion="10"
               android:targetSdkVersion="$api_level$" />
 
     <application android:icon="@drawable/android:star_big_on"

--- a/src/main/g8/android/src/main/AndroidManifest.xml
+++ b/src/main/g8/android/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
       android:versionCode="1"
       android:versionName="0.1">
 
-    <uses-sdk android:minSdkVersion="9"
+    <uses-sdk android:minSdkVersion="10"
               android:targetSdkVersion="$api_level$" />
 
     <application android:icon="@drawable/android:star_big_on"


### PR DESCRIPTION
While nearly all available today features important for games were included in
API level 9, because it:
- added concurrent garbage collector
- added new input sensors used often in games (gyroscope, linear acceleration)
- completed OpenGL ES 2.0 with earlier missing glDrawElements and
  glVertexAttribPointer
- added xlarge screens
- added NativeActivity
- added NFC
- copies whole data at once when creating FloatBuffer like desktop Java,
  instead of doing it one by one like earlier Android API versions (massive
  performance gain for games)

There seems to be several reasons to use API level 10 instead:
- Google silently omits link to this version of API (API 9 is said to have
  serious bugs, but I'm unaware what they are)
- Google does not distribute SDK platform files for API 9 so we cannot test
  apps in emulator
- It is very very hard to find device with API 9, only 0.1% of devices use it
  vs 36.4% of API 10 devices out there
- API 10 came 3 months after API 9 and most if not all devices were compatible
  and upgraded
- we are speaking about default, so if someone wants, he can lover it even to
  API 3, 4, 7 or 8
