### PR TITLE
Add OpenGL ES 2.0 to required Android features

### DIFF
--- a/src/main/g8/android-tests/src/main/AndroidManifest.xml
+++ b/src/main/g8/android-tests/src/main/AndroidManifest.xml
@@ -21,6 +21,8 @@
 
     <uses-permission android:name="android.permission.WAKE_LOCK" />
 
+    <uses-feature android:glEsVersion="0x00020000"/>
+
     <instrumentation android:label="Tests"
                      android:targetPackage="$package$"
                      android:name="android.test.InstrumentationTestRunner" />

--- a/src/main/g8/android/src/main/AndroidManifest.xml
+++ b/src/main/g8/android/src/main/AndroidManifest.xml
@@ -20,4 +20,6 @@
 
     <uses-permission android:name="android.permission.WAKE_LOCK" />
 
+    <uses-feature android:glEsVersion="0x00020000"/>
+
 </manifest>


### PR DESCRIPTION
OpenGL ES 2.0 is used by default in template, so it should be forced on devices
by adding uses-feature in AndroidManifest.xml:

```
<uses-feature android:glEsVersion="0x00020000"/>
```
