### PR TITLE
Added sbt-assembly for desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Run the desktop project:
 
     $ sbt "project desktop" run
 
+Package the desktop project into single jar:
+
+    $ sbt assembly
+
 Run the android project on a device:
   
     $ sbt android:start-device

--- a/src/main/g8/project/build.scala
+++ b/src/main/g8/project/build.scala
@@ -3,6 +3,8 @@ import sbt._
 import Keys._
 import org.scalasbt.androidplugin._
 import org.scalasbt.androidplugin.AndroidKeys._
+import sbtassembly.Plugin._
+import AssemblyKeys._
 
 object Settings {
   lazy val scalameter = new TestFramework("org.scalameter.ScalaMeterFramework")
@@ -17,7 +19,7 @@ object Settings {
     testOptions += Tests.Argument(scalameter, "-preJDK7")
    )
 
-  lazy val desktop = Settings.common ++ Seq (
+  lazy val desktop = Settings.common ++ assemblySettings ++ Seq (
     fork in Compile := true
   )
 
@@ -100,7 +102,10 @@ object LibgdxBuild extends Build {
     "desktop",
     file("desktop"),
     settings = Settings.desktop
-  ) dependsOn(common % "compile->compile;test->test")
+  ) dependsOn(common % "compile->compile;test->test") settings(
+    mainClass in assembly := Some("$package$.Main"),
+    AssemblyKeys.jarName in assembly := "$name$-0.1.jar"
+  )
 
   lazy val android = Project (
     "android",

--- a/src/main/g8/project/plugins.sbt
+++ b/src/main/g8/project/plugins.sbt
@@ -1,3 +1,5 @@
 resolvers += Resolver.url("scalasbt snapshots", new URL("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-snapshots"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("org.scala-sbt" % "sbt-android-plugin" % "0.6.3-20130429-SNAPSHOT") 
+addSbtPlugin("org.scala-sbt" % "sbt-android-plugin" % "0.6.3-20130429-SNAPSHOT")
+
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.9.0")


### PR DESCRIPTION
While it is easy to create/deploy application for Android thanks to sbt-android
and proguard, there was no easy way to build application for PC. sbt-assembly
approach seems to be one that "just works" without any specific configuration,
so one can run:

```
$ sbt assembly
```

and get nice jar bundled with everything needed to run application, including
scala libraries, libgdx and shared libraries.
