### PR TITLE
Fix duplicate assets in apk file

### DIFF
--- a/src/main/g8/project/build.scala
+++ b/src/main/g8/project/build.scala
@@ -20,6 +20,7 @@ object Settings {
    )
 
   lazy val desktop = Settings.common ++ assemblySettings ++ Seq (
+    unmanagedResourceDirectories in Compile += file("common/assets"),
     fork in Compile := true
   )
 
@@ -28,7 +29,7 @@ object Settings {
     AndroidMarketPublish.settings ++ Seq (
       platformName in Android := "android-$api_level$",
       keyalias in Android := "change-me",
-      mainAssetsPath in Android := file("common/src/main/resources"),
+      mainAssetsPath in Android := file("common/assets"),
       unmanagedBase <<= baseDirectory( _ /"src/main/libs" ),
       proguardOption in Android <<= (baseDirectory) {
         (b) => scala.io.Source.fromFile(b / "src/main/proguard.cfg").getLines.map(_.takeWhile(_!='#')).filter(_!="").mkString("\n")


### PR DESCRIPTION
For desktop, asset files were copied into common/target instead of
desktop/target, resulting in duplicate resources inside apk file. This simple
directory move solves this issue.
