### PR TITLE
Avoid using spaces in names

### DIFF
--- a/src/main/g8/android-tests/src/main/res/values/strings.xml
+++ b/src/main/g8/android-tests/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">$name$</string>
+    <string name="app_name">$name$ Tests</string>
 </resources>

--- a/src/main/g8/ios/$name__norm$-ios.csproj
+++ b/src/main/g8/ios/$name__norm$-ios.csproj
@@ -163,7 +163,7 @@
       <HintPath>libs\ios\objectal\libObjectAL.dll</HintPath>
     </Reference>
     <Reference Include="$name$">
-      <HintPath>target/$name$.dll</HintPath>
+      <HintPath>target/$name;format="norm"$.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/main/g8/ios/$name__norm$-ios.sln
+++ b/src/main/g8/ios/$name__norm$-ios.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 11.00
 # Visual Studio 2010
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "$name$-ios", "$name$-ios.csproj", "{E9434FE8-789E-4EF9-AD1E-40F73DBA497B}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "$name$-ios", "$name;format="norm"$-ios.csproj", "{E9434FE8-789E-4EF9-AD1E-40F73DBA497B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/main/g8/ios/convert.properties
+++ b/src/main/g8/ios/convert.properties
@@ -2,5 +2,5 @@ SRC =       ../common/src/main/scala
 CLASSPATH = ../common/lib/gdx.jar
 EXCLUDE   =
 IN        = -r:libs/ios/gdx.dll -recurse:\${user.home}/.sbt/boot/scala-$scala_version$/lib/scala-library.jar -recurse:target/*.class
-OUT       = target/$name$.dll
+OUT       = target/$name;format="norm"$.dll
 

--- a/src/main/g8/project/build.scala
+++ b/src/main/g8/project/build.scala
@@ -26,6 +26,7 @@ object Settings {
   lazy val android = Settings.common ++
     AndroidProject.androidSettings ++
     AndroidMarketPublish.settings ++ Seq (
+      name := "$name$",
       platformName in Android := "android-$api_level$",
       keyalias in Android := "change-me",
       mainAssetsPath in Android := file("common/src/main/resources"),
@@ -104,7 +105,7 @@ object LibgdxBuild extends Build {
     settings = Settings.desktop
   ) dependsOn(common % "compile->compile;test->test") settings(
     mainClass in assembly := Some("$package$.Main"),
-    AssemblyKeys.jarName in assembly := "$name$-0.1.jar"
+    AssemblyKeys.jarName in assembly := "$name;format="norm"$-0.1.jar"
   )
 
   lazy val android = Project (
@@ -124,6 +125,6 @@ object LibgdxBuild extends Build {
     file("android-tests"),
     settings = Settings.android ++
                AndroidTest.androidSettings ++
-               Seq ( name := "$name$Tests" )
+               Seq ( name := "$name$ Tests" )
   ) dependsOn android
 }


### PR DESCRIPTION
This change avoids spaces in file names, that were created if space was
included in game name. Now, all references to game name in files are
normalized (lowercase, with hyphens instead of spaces). Also, I made sure that
assembly and apk files get correct names set both as files, and internally
(instrumentation tests were overwriting main game).
