### PR TITLE
build.scala cleanup (preparation for fixing android-tests paths)

### DIFF
--- a/src/main/g8/android-tests/src/main/proguard.cfg
+++ b/src/main/g8/android-tests/src/main/proguard.cfg
@@ -1,0 +1,37 @@
+## Scala
+
+# Fix accesses to class members by means of introspection
+-keepclassmembernames class scala.concurrent.forkjoin.ForkJoinPool {
+    long ctl;
+    long stealCount;
+    int plock;
+    int qlock;
+    int indexSeed;
+    ** parkBlocker; # I can't find what type it should be, so keep all
+}
+-keepclassmembernames class scala.concurrent.forkjoin.ForkJoinPool\$WorkQueue {
+    int qlock;
+}
+-keepclassmembernames class scala.concurrent.forkjoin.ForkJoinTask {
+    int status;
+}
+-keepclassmembernames class scala.concurrent.forkjoin.LinkedTransferQueue {
+    scala.concurrent.forkjoin.LinkedTransferQueue\$Node head;
+    scala.concurrent.forkjoin.LinkedTransferQueue\$Node tail;
+    int sweepVotes;
+}
+-keepclassmembernames class scala.concurrent.forkjoin.LinkedTransferQueue\$Node {
+    java.lang.Object item;
+    scala.concurrent.forkjoin.LinkedTransferQueue\$Node next;
+    java.lang.Thread waiter;
+}
+
+# See bug https://issues.scala-lang.org/browse/SI-5397
+-keep class scala.collection.SeqLike { public protected *; }
+# This needs also descriptor classes
+-keep public class scala.Function1
+-keep public class scala.Function2
+-keep public class scala.collection.GenSeq
+-keep public class scala.collection.generic.CanBuildFrom
+-keep public class scala.math.Ordering
+


### PR DESCRIPTION
Some clean-ups to build.scala. Especially, I separated settings common for
android and android_tests into android_common references by both, also copying
needed jars and shared objects into android_tests as well.
