### PR TITLE
Simple changes to default settings

### DIFF
--- a/src/main/g8/android/src/main/AndroidManifest.xml
+++ b/src/main/g8/android/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
       package="$package$"
+      android:installLocation="preferExternal"
       android:versionCode="1"
       android:versionName="0.1">
 
@@ -10,7 +11,10 @@
     <application android:icon="@drawable/android:star_big_on"
                  android:label="@string/app_name"
                  android:debuggable="true">
-        <activity android:name=".Main" android:label="@string/app_name">
+        <activity android:name=".Main"
+                  android:label="@string/app_name"
+                  android:screenOrientation="portrait"
+                  android:configChanges="keyboard|keyboardHidden|orientation|screenSize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
@@ -20,6 +24,6 @@
 
     <uses-permission android:name="android.permission.WAKE_LOCK" />
 
-    <uses-feature android:glEsVersion="0x00020000"/>
+    <uses-feature android:glEsVersion="0x00010000"/>
 
 </manifest>

--- a/src/main/g8/android/src/main/scala/Main.scala
+++ b/src/main/g8/android/src/main/scala/Main.scala
@@ -10,7 +10,8 @@ class Main extends AndroidApplication {
     config.useAccelerometer = false
     config.useCompass = false
     config.useWakelock = true
-    config.useGL20 = true
+    config.hideStatusBar = true
+    config.useGL20 = false
     initialize(new $main_class$(), config)
   }
 }

--- a/src/main/g8/desktop/src/main/scala/Main.scala
+++ b/src/main/g8/desktop/src/main/scala/Main.scala
@@ -5,9 +5,9 @@ import com.badlogic.gdx.backends.lwjgl._
 object Main extends App {
     val cfg = new LwjglApplicationConfiguration()
     cfg.title = "$name$"
-    cfg.height = 480
     cfg.width = 320
-    cfg.useGL20 = true
+    cfg.height = 480
+    cfg.useGL20 = false
     cfg.forceExit = false
     new LwjglApplication(new $main_class$(), cfg)
 }


### PR DESCRIPTION
Few simple changes to default settings to demonstrate useful options and
follow recommended settings.
- installLocation set to preferExternal
- screenOrientation set to portrait
- configChanges set to capture changes to keyboard and screen
- hide status bar on Android devices
- use OpenGL ES 1.x instead of 2.x

For reference see http://code.google.com/p/libgdx/wiki/ApplicationConfiguration
