### PR TITLE
rebase of desktop proguard

### DIFF
--- a/src/main/g8/android/src/main/proguard.cfg
+++ b/src/main/g8/android/src/main/proguard.cfg
@@ -25,6 +25,12 @@
 -keep public class com.badlogic.gdx.net.ServerSocketHints
 -keep public class com.badlogic.gdx.utils.Array
 -keep public class com.badlogic.gdx.audio.Music\$OnCompletionListener
+-keep public class com.badlogic.gdx.graphics.Pixmap
+
+# Uncomment for Libgdx 1.0.0-SNAPSHOT
+#-keep public class com.badlogic.gdx.backends.android.AndroidVisibilityListener {
+#  public void createListener(com.badlogic.gdx.backends.android.AndroidApplication);
+#}
 
 ## Scala
 

--- a/src/main/g8/android/src/main/proguard.cfg
+++ b/src/main/g8/android/src/main/proguard.cfg
@@ -1,71 +1,8 @@
-## Entry point
-
--keep public class $package$.Main
-
-## LibGDX
-
 # Keep Android backend
 -keep class com.badlogic.gdx.backends.android.** { *; }
-# This needs also descriptor classes
--keep public class com.badlogic.gdx.Screen
--keep public class com.badlogic.gdx.Application
--keep public class com.badlogic.gdx.ApplicationListener
--keep public class com.badlogic.gdx.LifecycleListener
--keep public class com.badlogic.gdx.InputProcessor
--keep public class com.badlogic.gdx.files.FileHandle
--keep public class com.badlogic.gdx.Files\$FileType
--keep public class com.badlogic.gdx.Graphics\$DisplayMode
--keep public class com.badlogic.gdx.Input\$TextInputListener
--keep public class com.badlogic.gdx.Input\$Peripheral
--keep public class com.badlogic.gdx.Input\$Orientation
--keep public class com.badlogic.gdx.Net\$HttpRequest
--keep public class com.badlogic.gdx.Net\$HttpResponseListener
--keep public class com.badlogic.gdx.Net\$Protocol
--keep public class com.badlogic.gdx.net.SocketHints
--keep public class com.badlogic.gdx.net.ServerSocketHints
--keep public class com.badlogic.gdx.utils.Array
--keep public class com.badlogic.gdx.audio.Music\$OnCompletionListener
--keep public class com.badlogic.gdx.graphics.Pixmap
 
 # Uncomment for Libgdx 1.0.0-SNAPSHOT
 #-keep public class com.badlogic.gdx.backends.android.AndroidVisibilityListener {
 #  public void createListener(com.badlogic.gdx.backends.android.AndroidApplication);
 #}
-
-## Scala
-
-# Fix accesses to class members by means of introspection
--keepclassmembernames class scala.concurrent.forkjoin.ForkJoinPool {
-    ** ctl;
-    ** stealCount;
-    ** plock;
-    ** qlock;
-    ** indexSeed;
-    ** parkBlocker;
-}
--keepclassmembernames class scala.concurrent.forkjoin.ForkJoinPool\$WorkQueue {
-    ** qlock;
-}
--keepclassmembernames class scala.concurrent.forkjoin.ForkJoinTask {
-    ** status;
-}
--keepclassmembernames class scala.concurrent.forkjoin.LinkedTransferQueue {
-    ** head;
-    ** tail;
-    ** sweepVotes;
-}
--keepclassmembernames class scala.concurrent.forkjoin.LinkedTransferQueue\$Node {
-    ** item;
-    ** next;
-    ** waiter;
-}
-
-# See bug https://issues.scala-lang.org/browse/SI-5397
--keep class scala.collection.SeqLike { public protected *; }
-# This needs also descriptor classes
--keep public class scala.Function1
--keep public class scala.Function2
--keep public class scala.collection.GenSeq
--keep public class scala.collection.generic.CanBuildFrom
--keep public class scala.math.Ordering
 

--- a/src/main/g8/common/src/main/proguard.cfg
+++ b/src/main/g8/common/src/main/proguard.cfg
@@ -1,0 +1,66 @@
+## Entry point
+
+-keep public class $package$.Main
+
+## LibGDX
+
+# keep used
+
+# This needs also descriptor classes
+-keep public class com.badlogic.gdx.Screen
+-keep public class com.badlogic.gdx.Application
+-keep public class com.badlogic.gdx.ApplicationListener
+-keep public class com.badlogic.gdx.LifecycleListener
+-keep public class com.badlogic.gdx.InputProcessor
+-keep public class com.badlogic.gdx.files.FileHandle
+-keep public class com.badlogic.gdx.Files\$FileType
+-keep public class com.badlogic.gdx.Graphics\$DisplayMode
+-keep public class com.badlogic.gdx.Input\$TextInputListener
+-keep public class com.badlogic.gdx.Input\$Peripheral
+-keep public class com.badlogic.gdx.Input\$Orientation
+-keep public class com.badlogic.gdx.Net\$HttpRequest
+-keep public class com.badlogic.gdx.Net\$HttpResponseListener
+-keep public class com.badlogic.gdx.Net\$Protocol
+-keep public class com.badlogic.gdx.net.SocketHints
+-keep public class com.badlogic.gdx.net.ServerSocketHints
+-keep public class com.badlogic.gdx.utils.Array
+-keep public class com.badlogic.gdx.audio.Music\$OnCompletionListener
+-keep public class com.badlogic.gdx.graphics.Pixmap
+
+## Scala
+
+# Fix accesses to class members by means of introspection
+-keepclassmembernames class scala.concurrent.forkjoin.ForkJoinPool {
+    ** ctl;
+    ** stealCount;
+    ** plock;
+    ** qlock;
+    ** indexSeed;
+    ** parkBlocker;
+}
+-keepclassmembernames class scala.concurrent.forkjoin.ForkJoinPool\$WorkQueue {
+    ** qlock;
+}
+-keepclassmembernames class scala.concurrent.forkjoin.ForkJoinTask {
+    ** status;
+}
+-keepclassmembernames class scala.concurrent.forkjoin.LinkedTransferQueue {
+    ** head;
+    ** tail;
+    ** sweepVotes;
+}
+-keepclassmembernames class scala.concurrent.forkjoin.LinkedTransferQueue\$Node {
+    ** item;
+    ** next;
+    ** waiter;
+}
+
+# See bug https://issues.scala-lang.org/browse/SI-5397
+-keep class scala.collection.SeqLike { public protected *; }
+# This needs also descriptor classes
+-keep public class scala.Function1
+-keep public class scala.Function2
+-keep public class scala.collection.GenSeq
+-keep public class scala.collection.generic.CanBuildFrom
+-keep public class scala.math.Ordering
+

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -1,6 +1,6 @@
 name=My Game
 main_class=MyGame
 package=my.game.pkg
-api_level=17
+api_level=19
 scala_version=2.10.3
 libgdx_version=0.9.9

--- a/src/main/g8/desktop/src/main/manifest/META-INF/MANIFEST.MF
+++ b/src/main/g8/desktop/src/main/manifest/META-INF/MANIFEST.MF
@@ -1,0 +1,2 @@
+Main-Class: $package$.Main
+

--- a/src/main/g8/desktop/src/main/proguard.cfg
+++ b/src/main/g8/desktop/src/main/proguard.cfg
@@ -1,0 +1,53 @@
+# Inform ProGuard about Java Runtime
+-libraryjars <java.home>/lib/rt.jar
+
+# keep main method
+-keepclasseswithmembers public class $package$.Main {
+    public static void main(java.lang.String[]);
+}
+
+# Keep LWJGL backend
+-keep class com.badlogic.gdx.backends.lwjgl.** { *; }
+-keep class com.badlogic.gdx.backends.openal.** { *; }
+-keep class org.lwjgl.** { *; }
+
+# keep controller related classes
+-keep class net.java.games.input.Component\$Identifier { *; }
+-keep class net.java.games.input.Component { *; }
+-keep class net.java.games.input.Controller { *; }
+-keep class net.java.games.input.Rumbler { *; }
+-keep class net.java.games.input.Event { *; }
+-keep class net.java.games.input.ControllerListener { *; }
+-keep class net.java.games.input.ControllerEvent { *; }
+-keep class net.java.games.input.Component\$Identifier\$Key { *; }
+
+# used by LWJGL to open web browser, by libgdx to detect when it runs in javaws
+# in both cases it is guarded and will be provided by java library
+-dontnote javax.jnlp.**
+-dontnote com.badlogic.gdx.backends.lwjgl.LwjglNativesLoader
+
+# all notes from LWJGL comes from dynamically calling its own or java library
+# functions. It includes cases like having multiple definitions for GL 1 and 2.
+# same goes for libgdx OpenAL audio, that dynamically uses proper decoder for
+# music files.
+-dontnote org.lwjgl.**
+-dontnote com.badlogic.gdx.backends.openal.OpenALAudio
+
+# Settings mirrored from sbt-android
+-dontoptimize
+-dontwarn
+-dontobfuscate
+
+-dontnote scala.Enumeration
+-dontnote org.xml.sax.EntityResolver
+
+-keep class scala.reflect.ScalaSignature
+
+-keepclassmembers class * implements java.io.Serializable {
+    private static final java.io.ObjectStreamField[] serialPersistentFields;
+    private void writeObject(java.io.ObjectOutputStream);
+    private void readObject(java.io.ObjectInputStream);
+    java.lang.Object writeReplace();
+    java.lang.Object readResolve();
+}
+

--- a/src/main/g8/project/build.scala
+++ b/src/main/g8/project/build.scala
@@ -103,7 +103,7 @@ object Tasks {
 
   lazy val assemblyKey = TaskKey[Unit]("assembly", "Assembly desktop using Proguard")
 
-  lazy val assembly = assemblyKey <<= (compile in Compile, // dependency to make sure compile finished
+  lazy val assembly = assemblyKey <<= (fullClasspath in Runtime, // dependency to make sure compile finished
       target, desktopJarName, version, // data for output jar name
       proguardOptions, // merged proguard.cfg from common and desktop
       javaOptions in Compile, managedClasspath in Compile, // java options and classpath

--- a/src/main/g8/project/plugins.sbt
+++ b/src/main/g8/project/plugins.sbt
@@ -2,6 +2,4 @@ resolvers += Resolver.url("scalasbt snapshots", new URL("http://repo.scala-sbt.o
 
 addSbtPlugin("org.scala-sbt" % "sbt-android" % "0.7")
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.9.2")
-
 addSbtPlugin("com.hagerbot" % "sbt-robovm" % "0.1.0-SNAPSHOT")


### PR DESCRIPTION
I've rebased last pull request about proguard for desktop. There were few minor mistakes, not I've actually run more tests (including applications with assets). It cuts simple project by 10mb (to 6 from 16), most of which is platform dependent stuff.

I think that separate building of platform dependent libraries can be considered later.

(note: This was https://github.com/ajhager/libgdx-sbt-project.g8/pull/50 but I decided that mavenization of project touched build.scala in so many places,that it was easier to make new, fresh pull request. I'm linking it, so discussion below it does not disappear).
