### PR TITLE
support different libgdx versions

### DIFF
--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -2,5 +2,5 @@ name=My Game
 main_class=MyGame
 package=my.game.pkg
 api_level=17
-scala_version=2.10.2
+scala_version=2.10.3
 libgdx_version=0.9.9

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -3,3 +3,4 @@ main_class=MyGame
 package=my.game.pkg
 api_level=17
 scala_version=2.10.2
+libgdx_version=0.9.9

--- a/src/main/g8/project/build.scala
+++ b/src/main/g8/project/build.scala
@@ -30,7 +30,7 @@ object Settings {
     unmanagedBase <<= baseDirectory(_/"libs"),
     resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
     libraryDependencies ++= Seq(
-      "com.badlogicgames.gdx" % "gdx" % "0.9.9-SNAPSHOT"
+      "com.badlogicgames.gdx" % "gdx" % "$libgdx_version$"
     )
   )
 
@@ -38,8 +38,8 @@ object Settings {
     unmanagedResourceDirectories in Compile += file("common/assets"),
     fork in Compile := true,
     libraryDependencies ++= Seq(
-      "com.badlogicgames.gdx" % "gdx-backend-lwjgl" % "0.9.9-SNAPSHOT",
-      "com.badlogicgames.gdx" % "gdx-platform" % "0.9.9-SNAPSHOT" classifier "natives-desktop"
+      "com.badlogicgames.gdx" % "gdx-backend-lwjgl" % "$libgdx_version$",
+      "com.badlogicgames.gdx" % "gdx-platform" % "$libgdx_version$" classifier "natives-desktop"
     )
   )
 
@@ -53,9 +53,9 @@ object Settings {
       scala.io.Source.fromFile(b/"src/main/proguard.cfg").getLines.map(_.takeWhile(_!='#')).filter(_!="").mkString("\n")
     )},
     libraryDependencies ++= Seq(
-      "com.badlogicgames.gdx" % "gdx-backend-android" % "0.9.9-SNAPSHOT",
-      "com.badlogicgames.gdx" % "gdx-platform" % "0.9.9-SNAPSHOT" % "natives" classifier "natives-armeabi",
-      "com.badlogicgames.gdx" % "gdx-platform" % "0.9.9-SNAPSHOT" % "natives" classifier "natives-armeabi-v7a"
+      "com.badlogicgames.gdx" % "gdx-backend-android" % "$libgdx_version$",
+      "com.badlogicgames.gdx" % "gdx-platform" % "$libgdx_version$" % "natives" classifier "natives-armeabi",
+      "com.badlogicgames.gdx" % "gdx-platform" % "$libgdx_version$" % "natives" classifier "natives-armeabi-v7a"
     ),
     nativeExtractions <<= (baseDirectory) { base => Seq(
       ("natives-armeabi.jar", new ExactFilter("libgdx.so"), base / "lib" / "armeabi"),
@@ -73,8 +73,8 @@ object Settings {
     frameworks := Seq("UIKit", "OpenGLES", "QuartzCore", "CoreGraphics", "OpenAL", "AudioToolbox", "AVFoundation"),
     nativePath <<= (baseDirectory){ bd => Seq(bd / "lib") },
     libraryDependencies ++= Seq(
-      "com.badlogicgames.gdx" % "gdx-backend-robovm" % "0.9.9-SNAPSHOT",
-      "com.badlogicgames.gdx" % "gdx-platform" % "0.9.9-SNAPSHOT" % "natives" classifier "natives-ios"
+      "com.badlogicgames.gdx" % "gdx-backend-robovm" % "$libgdx_version$",
+      "com.badlogicgames.gdx" % "gdx-platform" % "$libgdx_version$" % "natives" classifier "natives-ios"
     ),
     nativeExtractions <<= (baseDirectory) { base => Seq(
       ("natives-ios.jar", new ExactFilter("libgdx.a") | new ExactFilter("libObjectAL.a"), base / "lib")


### PR DESCRIPTION
This is important and often changes. For example, 0.9.9-SNAPSHOT is no longer published since 0.9.9 was released. I think such solution is enough for now. If someone enter stable release, he just ends up with extra "resolver" for snapshots that isn't used, so not a big deal. What do you think?
