### PR TITLE
The tasks should be cancelable(terminated without exiting sbt)

### DIFF
--- a/src/main/g8/project/build.scala
+++ b/src/main/g8/project/build.scala
@@ -31,7 +31,8 @@ object Settings {
     resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
     libraryDependencies ++= Seq(
       "com.badlogicgames.gdx" % "gdx" % "$libgdx_version$"
-    )
+    ),
+    cancelable := true
   )
 
   lazy val desktop = common ++ assemblySettings ++ Seq(


### PR DESCRIPTION
I noticed when I terminated a task, like `ios/ipad-sim`, with `Ctrl+C`, the sbt would be terminated as well. It's a little annoying, and `cancelable` option fixes it.
