### PR TITLE
More explicit and verbose scalac and javac options

### DIFF
--- a/src/main/g8/project/build.scala
+++ b/src/main/g8/project/build.scala
@@ -14,7 +14,9 @@ object Settings {
     version := "0.1",
     scalaVersion := "$scala_version$",
     javacOptions ++= Seq("-encoding", "UTF-8", "-source", "1.6", "-target", "1.6"),
-    scalacOptions ++= Seq("-Xlint", "-unchecked", "-deprecation", "-feature"),
+    scalacOptions ++= Seq("-encoding", "UTF-8", "-target:jvm-1.6"),
+    javacOptions += "-Xlint",
+    scalacOptions ++= Seq("-Xlint", "-Ywarn-dead-code", "-Ywarn-value-discard", "-Ywarn-numeric-widen", "-unchecked", "-deprecation", "-feature"),
     resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
     libraryDependencies ++= Seq(
       "com.badlogicgames.gdx" % "gdx" % "$libgdx_version$"


### PR DESCRIPTION
Simple commit to enable few more warnings:
- all recommended for any Java compiled files
- 3 extra warnings for Scala (they helped me to eliminate some non optimal code by pointing potential mistakes, they turned out to be quite useful)

A be little more explicit about source and target assumptions:
- encoding for Scala files
- explicit target for Scala output (JVM 1.6)
