### PR TITLE
Updated gitignore for new Android plugin

### DIFF
--- a/src/main/g8/.gitignore
+++ b/src/main/g8/.gitignore
@@ -4,3 +4,5 @@ target/
 src_managed/
 project/boot/
 project/plugins/project
+bin/
+gen/


### PR DESCRIPTION
New plugin keeps generated files in gen and build apk in bin.  Added to gitignore.
