### PR TITLE
Update to android-sdk-plugin 1.3.1

### DIFF
--- a/src/main/g8/project/plugins.sbt
+++ b/src/main/g8/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.hanhuy.sbt" % "android-sdk-plugin" % "1.2.19")
+addSbtPlugin("com.hanhuy.sbt" % "android-sdk-plugin" % "1.3.1")


### PR DESCRIPTION
It should enable Android NDK support and more new upstream features.

Seems to work at least as good as previous version of plugin, kind of trivial update.
