### PR TITLE
Fixed assets directory on desktop.

### DIFF
--- a/src/main/g8/project/build.scala
+++ b/src/main/g8/project/build.scala
@@ -51,6 +51,7 @@ object Settings {
       "com.badlogicgames.gdx" % "gdx-platform" % libgdxVersion.value classifier "natives-desktop"
     ),
     fork in Compile := true,
+    baseDirectory in run := file("android/assets"),
     unmanagedResourceDirectories in Compile += file("android/assets"),
     desktopJarName := "$name;format="norm"$",
     Tasks.assembly


### PR DESCRIPTION
I'm not really sure if this is the right way to fix this, but at least it makes Gdx.files.internal("") behave consistently across Android and Desktop.
